### PR TITLE
fix ruamel.yaml on 0.14.X for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     description='Desktop application SDK for creating Universal Linux Applications.',
     install_requires=[
         'PyQt5',
-        'ruamel.yaml',
+        'ruamel.yaml<0.15',
     ],
     package_data={
         '': ['whither.yml'],


### PR DESCRIPTION
Thank you for using ruamel.yaml. 

There will be API changes in the 0.15+ versions, that might lead to warnings that 
your users could see. 
Therefore please release a version of your package with this change, so that it will not 
automatically take the latest ruamel.yaml release.